### PR TITLE
Comment console.log call from cbcore.ts

### DIFF
--- a/cbcore.ts
+++ b/cbcore.ts
@@ -177,7 +177,7 @@ namespace cyberbot {
             freq.setNumber(NumberFormat.Int32LE, 0, Math.round(f))
             args = Buffer.concat([args, freq]);
         }
-        console.log(args.toHex())
+        // console.log(args.toHex())
         pins.i2cWriteBuffer(ADDRESS, args);
 
         // build command and write


### PR DESCRIPTION
This change removes the source of the unwanted diagnostic data that is being sent to the Show data Device console.